### PR TITLE
Allow firebase/php-jwt:^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"ext-pdo": "*",
 		"guzzlehttp/guzzle": "^7.0",
 		"psr/log": "^1.1.4",
-		"firebase/php-jwt": "^5.4",
+		"firebase/php-jwt": "^5.4 || ^6.0",
 		"kamermans/guzzle-oauth2-subscriber": "^1.0.8",
 		"microsoft/azure-storage-blob": "^1.5.2",
 		


### PR DESCRIPTION
As far as I can tell, `^6.0` is still compatible with this library: it only uses `JWT::encode`, whose new signature is compatible with the `^5.4` signature.

This would allow us and other users of this package to update `firebase/php-jwt` to the most recent version.